### PR TITLE
40 enhance mediatypeobject parsing

### DIFF
--- a/src/main/java/org/jqassistant/plugin/openapi/api/model/EncodingDescriptor.java
+++ b/src/main/java/org/jqassistant/plugin/openapi/api/model/EncodingDescriptor.java
@@ -1,0 +1,29 @@
+package org.jqassistant.plugin.openapi.api.model;
+
+import com.buschmais.xo.neo4j.api.annotation.Label;
+import com.buschmais.xo.neo4j.api.annotation.Relation;
+import io.swagger.v3.oas.models.media.Encoding;
+
+import java.util.List;
+
+@Label("ENCODING")
+public interface EncodingDescriptor extends OpenApiDescriptor{
+
+    String getPropertyName();
+    void setPropertyName(String propertyName);
+
+    String getContentType();
+    void setContentType(String contentType);
+
+    @Relation("ACCEPTS")
+    List<HeaderDescriptor> getHeaders();
+
+    Encoding.StyleEnum getStyle();
+    void setStyle(Encoding.StyleEnum style);
+
+    boolean getExplode();
+    void setExplode(boolean explode);
+
+    boolean getAllowsReserved();
+    void setAllowsReserved(boolean allowsReserved);
+}

--- a/src/main/java/org/jqassistant/plugin/openapi/api/model/MediaTypeObjectDescriptor.java
+++ b/src/main/java/org/jqassistant/plugin/openapi/api/model/MediaTypeObjectDescriptor.java
@@ -21,6 +21,6 @@ public interface MediaTypeObjectDescriptor extends OpenApiDescriptor{
     @Relation("PROVIDES")
     List<ExampleDescriptor> getExamples();
 
-    @Relation("DEFINED_BY")
+    @Relation("USES")
     List<EncodingDescriptor> getEncodings();
 }

--- a/src/main/java/org/jqassistant/plugin/openapi/api/model/MediaTypeObjectDescriptor.java
+++ b/src/main/java/org/jqassistant/plugin/openapi/api/model/MediaTypeObjectDescriptor.java
@@ -1,9 +1,25 @@
 package org.jqassistant.plugin.openapi.api.model;
 
 import com.buschmais.xo.neo4j.api.annotation.Label;
+import com.buschmais.xo.neo4j.api.annotation.Relation;
+import org.jqassistant.plugin.openapi.api.model.jsonschema.JsonSchemaDescriptor;
+import java.util.List;
 
 @Label("MediaTypeObject")
 public interface MediaTypeObjectDescriptor extends OpenApiDescriptor{
     String getMediaType();
     void setMediaType(String mediaType);
+
+    @Relation("DEFINED_BY")
+    JsonSchemaDescriptor getSchema();
+    void setSchema(JsonSchemaDescriptor schema);
+
+    Object getExample();
+    void setExample(Object example);
+
+    @Relation("PROVIDES")
+    List<ExampleDescriptor> getExamples();
+
+    @Relation("DEFINED_BY")
+    List<EncodingDescriptor> getEncodings();
 }

--- a/src/main/java/org/jqassistant/plugin/openapi/api/model/MediaTypeObjectDescriptor.java
+++ b/src/main/java/org/jqassistant/plugin/openapi/api/model/MediaTypeObjectDescriptor.java
@@ -2,7 +2,8 @@ package org.jqassistant.plugin.openapi.api.model;
 
 import com.buschmais.xo.neo4j.api.annotation.Label;
 import com.buschmais.xo.neo4j.api.annotation.Relation;
-import org.jqassistant.plugin.openapi.api.model.jsonschema.JsonSchemaDescriptor;
+import org.jqassistant.plugin.openapi.api.model.jsonschema.SchemaDescriptor;
+
 import java.util.List;
 
 @Label("MediaTypeObject")
@@ -11,8 +12,8 @@ public interface MediaTypeObjectDescriptor extends OpenApiDescriptor{
     void setMediaType(String mediaType);
 
     @Relation("DEFINED_BY")
-    JsonSchemaDescriptor getSchema();
-    void setSchema(JsonSchemaDescriptor schema);
+    SchemaDescriptor getSchema();
+    void setSchema(SchemaDescriptor schema);
 
     Object getExample();
     void setExample(Object example);

--- a/src/main/java/org/jqassistant/plugin/openapi/api/model/ResponseDescriptor.java
+++ b/src/main/java/org/jqassistant/plugin/openapi/api/model/ResponseDescriptor.java
@@ -15,5 +15,5 @@ public interface ResponseDescriptor extends OpenApiDescriptor{
     void setDescription(String description);
 
     @Relation("CONTAINS")
-    List<MediaTypeObjectDescriptor> getMediaTypeObject();
+    List<MediaTypeObjectDescriptor> getMediaTypeObjects();
 }

--- a/src/main/java/org/jqassistant/plugin/openapi/impl/parsers/MediaTypeParser.java
+++ b/src/main/java/org/jqassistant/plugin/openapi/impl/parsers/MediaTypeParser.java
@@ -1,8 +1,12 @@
 package org.jqassistant.plugin.openapi.impl.parsers;
 
 import com.buschmais.jqassistant.core.store.api.Store;
+import io.swagger.v3.oas.models.media.Encoding;
 import io.swagger.v3.oas.models.media.MediaType;
+import org.jqassistant.plugin.openapi.api.model.EncodingDescriptor;
 import org.jqassistant.plugin.openapi.api.model.MediaTypeObjectDescriptor;
+import org.jqassistant.plugin.openapi.impl.jsonschema.JsonSchemaParser;
+import org.jqassistant.plugin.openapi.impl.util.Resolver;
 
 import java.util.List;
 import java.util.Map;
@@ -20,9 +24,42 @@ public class MediaTypeParser {
 
     public static MediaTypeObjectDescriptor parseOne(String mediaTypeType, MediaType mediaType, Store store){
         MediaTypeObjectDescriptor mediaTypeObjectDescriptor = store.create(MediaTypeObjectDescriptor.class);
+        JsonSchemaParser schemaParser = new JsonSchemaParser(new Resolver(store), store);
 
-        // read properties
         mediaTypeObjectDescriptor.setMediaType(mediaTypeType);
+
+        if(mediaType.getSchema() != null)
+            mediaTypeObjectDescriptor.setSchema(schemaParser.parseSchema(mediaType.getSchema(), null));
+        if(mediaType.getExampleSetFlag())
+            mediaTypeObjectDescriptor.setExample(mediaType.getExample());
+        if(mediaType.getExamples() != null)
+            mediaTypeObjectDescriptor.getExamples().addAll(ExampleParser.parseAll(mediaType.getExamples(), store));
+        if(mediaType.getEncoding() != null)
+            mediaTypeObjectDescriptor.getEncodings().addAll(parseEncodings(mediaType.getEncoding(), store));
+
         return mediaTypeObjectDescriptor;
+    }
+
+    private static List<EncodingDescriptor> parseEncodings(Map<String, Encoding> encodingsMap, Store store){
+        return encodingsMap.entrySet().stream().map(encodingEntry -> parseEncoding(encodingEntry.getKey(), encodingEntry.getValue(), store)).collect(Collectors.toList());
+    }
+
+    private static EncodingDescriptor parseEncoding(String propertyName, Encoding encoding, Store store){
+        EncodingDescriptor encodingDescriptor = store.create(EncodingDescriptor.class);
+
+        encodingDescriptor.setPropertyName(propertyName);
+
+        if(encoding.getContentType() != null)
+            encodingDescriptor.setContentType(encoding.getContentType());
+        if(encoding.getHeaders() != null)
+            encodingDescriptor.getHeaders().addAll(HeaderParser.parseAll(encoding.getHeaders(), store));
+        if(encoding.getStyle() != null)
+            encodingDescriptor.setStyle(encoding.getStyle());
+        if(encoding.getExplode() != null)
+            encodingDescriptor.setExplode(encoding.getExplode());
+        if(encoding.getAllowReserved() != null)
+            encodingDescriptor.setAllowsReserved(encoding.getAllowReserved());
+
+        return encodingDescriptor;
     }
 }

--- a/src/main/java/org/jqassistant/plugin/openapi/impl/parsers/ResponseParser.java
+++ b/src/main/java/org/jqassistant/plugin/openapi/impl/parsers/ResponseParser.java
@@ -37,7 +37,7 @@ public class ResponseParser {
 
         // read content
         if(response.getContent() != null)
-            responseDescriptor.getMediaTypeObject().addAll(MediaTypeParser.parseAll(response.getContent(), store));
+            responseDescriptor.getMediaTypeObjects().addAll(MediaTypeParser.parseAll(response.getContent(), store));
 
         return responseDescriptor;
 

--- a/src/main/resources/META-INF/jqassistant-plugin.xml
+++ b/src/main/resources/META-INF/jqassistant-plugin.xml
@@ -20,6 +20,7 @@
         <class>org.jqassistant.plugin.openapi.api.model.TagDescriptor</class>
         <class>org.jqassistant.plugin.openapi.api.model.PathsDescriptor</class>
         <class>org.jqassistant.plugin.openapi.api.model.ExternalDocsDescriptor</class>
+        <class>org.jqassistant.plugin.openapi.api.model.EncodingDescriptor</class>
         <class>org.jqassistant.plugin.openapi.api.model.jsonschema.ArrayPropertyDescriptor</class>
         <class>org.jqassistant.plugin.openapi.api.model.jsonschema.BoolPropertyDescriptor</class>
         <class>org.jqassistant.plugin.openapi.api.model.jsonschema.DiscriminatorDescriptor</class>

--- a/src/test/java/org/jqassistant/plugin/openapi/parser/ComponentsTest.java
+++ b/src/test/java/org/jqassistant/plugin/openapi/parser/ComponentsTest.java
@@ -36,6 +36,8 @@ class ComponentsTest extends AbstractPluginIT {
     void testRequestBodies() {
         List<RequestBodyDescriptor> requestBodies = contract.getComponents().getRequestBodies();
         assertThat(requestBodies).hasSize(1);
+
+        assertThat(requestBodies.get(0).getMediaTypeObjects()).hasSize(1);
     }
 
     @Test

--- a/src/test/java/org/jqassistant/plugin/openapi/parser/ComponentsTest.java
+++ b/src/test/java/org/jqassistant/plugin/openapi/parser/ComponentsTest.java
@@ -71,7 +71,34 @@ class ComponentsTest extends AbstractPluginIT {
     @Test
     void testResponses() {
         List<ResponseDescriptor> responses = contract.getComponents().getResponses();
-        assertThat(responses).hasSize(1);
+        assertThat(responses).hasSize(2);
+    }
+
+    @Test
+    void testMediaTypeObjects(){
+        ResponseDescriptor response404 = getResponseByName("418");
+        assertThat(response404.getMediaTypeObjects()).hasSize(3);
+
+        MediaTypeObjectDescriptor mtoExample = getMediaTypeObjectByName("multipart/form-data_example");
+        assertThat(mtoExample.getMediaType()).isEqualTo("multipart/form-data_example");
+        assertThat(mtoExample.getSchema()).isNotNull();
+        assertThat(mtoExample.getExample()).isNotNull();
+        assertThat(mtoExample.getExamples()).isEmpty();
+        assertThat(mtoExample.getEncodings()).hasSize(2);
+
+        MediaTypeObjectDescriptor mtoExamples = getMediaTypeObjectByName("multipart/form-data_examples");
+        assertThat(mtoExamples.getMediaType()).isEqualTo("multipart/form-data_examples");
+        assertThat(mtoExamples.getSchema()).isNotNull();
+        assertThat(mtoExamples.getExample()).isNull();
+        assertThat(mtoExamples.getExamples()).hasSize(2);
+        assertThat(mtoExamples.getEncodings()).isEmpty();
+
+        MediaTypeObjectDescriptor mtoEmpty = getMediaTypeObjectByName("multipart/form-data_empty");
+        assertThat(mtoEmpty.getMediaType()).isEqualTo("multipart/form-data_empty");
+        assertThat(mtoEmpty.getSchema()).isNull();
+        assertThat(mtoEmpty.getExample()).isNull();
+        assertThat(mtoEmpty.getExamples()).isEmpty();
+        assertThat(mtoEmpty.getEncodings()).isEmpty();
     }
 
     @Test
@@ -84,5 +111,22 @@ class ComponentsTest extends AbstractPluginIT {
     void testSchemas() {
         List<SchemaDescriptor> schemas = contract.getComponents().getSchemas();
         assertThat(schemas).hasSize(1);
+    }
+
+    private ResponseDescriptor getResponseByName(String name){
+        List<ResponseDescriptor> responses = contract.getComponents().getResponses();
+        for(ResponseDescriptor response: responses)
+            if(response.getStatusCode().equals(name))
+                return response;
+        return null;
+    }
+
+    private MediaTypeObjectDescriptor getMediaTypeObjectByName(String name){
+        List<ResponseDescriptor> responses = contract.getComponents().getResponses();
+        for(ResponseDescriptor response: responses)
+            for(MediaTypeObjectDescriptor mediaType: response.getMediaTypeObjects())
+                if(mediaType.getMediaType().equals(name))
+                    return mediaType;
+        return null;
     }
 }

--- a/src/test/java/org/jqassistant/plugin/openapi/parser/ComponentsTest.java
+++ b/src/test/java/org/jqassistant/plugin/openapi/parser/ComponentsTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import com.buschmais.jqassistant.core.scanner.api.DefaultScope;
 import com.buschmais.jqassistant.core.test.plugin.AbstractPluginIT;
+import io.swagger.v3.oas.models.media.Encoding;
 import org.jqassistant.plugin.openapi.api.model.*;
 import org.jqassistant.plugin.openapi.api.model.jsonschema.SchemaDescriptor;
 import org.junit.jupiter.api.AfterEach;
@@ -101,6 +102,28 @@ class ComponentsTest extends AbstractPluginIT {
         assertThat(mtoEmpty.getExample()).isNull();
         assertThat(mtoEmpty.getExamples()).isEmpty();
         assertThat(mtoEmpty.getEncodings()).isEmpty();
+    }
+
+    @Test
+    void testEncodings(){
+        MediaTypeObjectDescriptor mto = contract.getComponents().getRequestBodies().get(0).getMediaTypeObjects().get(0);
+        assertThat(mto.getEncodings()).hasSize(2);
+
+        EncodingDescriptor encoding1 = mto.getEncodings().get(0);
+        assertThat(encoding1.getPropertyName()).isEqualTo("property1");
+        assertThat(encoding1.getContentType()).isEqualTo("application/xml; charset=utf-8");
+        assertThat(encoding1.getHeaders()).hasSize(1);
+        assertThat(encoding1.getExplode()).isTrue();
+        assertThat(encoding1.getAllowsReserved()).isTrue();
+        assertThat(encoding1.getStyle()).isEqualTo(Encoding.StyleEnum.valueOf("SPACE_DELIMITED"));
+
+        EncodingDescriptor encoding2 = mto.getEncodings().get(1);
+        assertThat(encoding2.getPropertyName()).isEqualTo("property2");
+        assertThat(encoding2.getContentType()).isNull();
+        assertThat(encoding2.getHeaders()).isEmpty();
+        assertThat(encoding2.getExplode()).isFalse();
+        assertThat(encoding2.getAllowsReserved()).isFalse();
+        assertThat(encoding2.getStyle()).isEqualTo(Encoding.StyleEnum.valueOf("FORM"));
     }
 
     @Test

--- a/src/test/java/org/jqassistant/plugin/openapi/parser/OpenAPIScannerPluginTest.java
+++ b/src/test/java/org/jqassistant/plugin/openapi/parser/OpenAPIScannerPluginTest.java
@@ -9,32 +9,30 @@ import java.io.File;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
- class OpenAPIScannerPluginTest extends AbstractPluginIT {
+class OpenAPIScannerPluginTest extends AbstractPluginIT {
 
-     ContractDescriptor contract;
-
-     @Test
-     void scanNullContract(){
-         File file = new File(getClassesDirectory(OpenAPIScannerPluginTest.class), "example-nulltest.yaml");
-         try {
-             contract = getScanner().scan(file, "example-nulltest.yaml", DefaultScope.NONE);
-             assertThat(contract).isNotNull();
-         } catch (Exception e){
+    ContractDescriptor contract;
+    @Test
+    void scanNullContract(){
+        File file = new File(getClassesDirectory(OpenAPIScannerPluginTest.class), "example-nulltest.yaml");
+        try {
+            contract = getScanner().scan(file, "example-nulltest.yaml", DefaultScope.NONE);
+            assertThat(contract).isNotNull();
+        } catch (Exception e){
             fail("Reading contract not containing any data failed", e);
-         }
-     }
+        }
+    }
 
-     @Test
-     void scanEmptyContract(){  
-         File file = new File(getClassesDirectory(OpenAPIScannerPluginTest.class), "example-emptytest.yaml");
-         try {
-             contract = getScanner().scan(file, "example-emptytest.yaml", DefaultScope.NONE);
-             assertThat(contract).isNotNull();
-         } catch (Exception e){
-             fail("Reading contract only containing container data failed", e);
-         }
-     }
-
+    @Test
+    void scanEmptyContract(){
+        File file = new File(getClassesDirectory(OpenAPIScannerPluginTest.class), "example-emptytest.yaml");
+        try {
+            contract = getScanner().scan(file, "example-emptytest.yaml", DefaultScope.NONE);
+            assertThat(contract).isNotNull();
+        } catch (Exception e){
+            fail("Reading contract only containing container data failed", e);
+        }
+    }
 
     @Test
     void scanMetaData(){
@@ -66,54 +64,51 @@ import static org.assertj.core.api.Assertions.*;
         store.commitTransaction();
     }
 
-     @Test
-     void scanWholeContract(){
-         File file = new File(getClassesDirectory(OpenAPIScannerPluginTest.class), "example.yaml");
-         try {
-             ContractDescriptor contract = getScanner().scan(file, "example.yaml", DefaultScope.NONE);
-             assertThat(contract).isNotNull();
-         } catch (Exception e){
-             fail("Reading whole example contract failed", e);
-         }
-     }
+    @Test
+    void scanWholeContract(){
+        File file = new File(getClassesDirectory(OpenAPIScannerPluginTest.class), "example.yaml");
+        try {
+            ContractDescriptor contract = getScanner().scan(file, "example.yaml", DefaultScope.NONE);
+            assertThat(contract).isNotNull();
+        } catch (Exception e){
+            fail("Reading whole example contract failed", e);
+        }
+    }
 
-     @Test
-     void testExternalDocs(){
-
-         File file = new File(getClassesDirectory(OpenAPIScannerPluginTest.class), "example-metadata.yaml");
-         try {
-             contract = getScanner().scan(file, "example-metadata.yaml", DefaultScope.NONE);
-             assertThat(contract).isNotNull();
-         } catch (Exception e){
-             fail("Reading contract only containing container data failed", e);
-         }
-
-         store.beginTransaction();
-         ExternalDocsDescriptor externalDocsWithProperties = getTagByName("issues").getExternalDocs();
-         assertThat(externalDocsWithProperties.getDescription()).isEqualTo("issues - external docs description");
-         assertThat(externalDocsWithProperties.getUrl()).isEqualTo("https://www.1.example.com");
-
-         ExternalDocsDescriptor externalDocsWithoutDescription = getTagByName("externalDocs_without_description").getExternalDocs();
-         assertThat(externalDocsWithoutDescription.getDescription()).isNull();
-         assertThat(externalDocsWithoutDescription.getUrl()).isEqualTo("https://www.2.example.com");
-
-         ExternalDocsDescriptor externalDocsWithoutUrl = getTagByName("externalDocs_without_url").getExternalDocs();
-         assertThat(externalDocsWithoutUrl.getDescription()).isEqualTo("external docs without url");
-         assertThat(externalDocsWithoutUrl.getUrl()).isNull();
-
-         ExternalDocsDescriptor externalDocsWithEmptyProps = getTagByName("externalDocs_with_empty_props").getExternalDocs();
-         assertThat(externalDocsWithEmptyProps.getDescription()).isNull();
-         assertThat(externalDocsWithEmptyProps.getUrl()).isNull();
-
-         store.commitTransaction();
+    @Test
+    void testExternalDocs(){
+        File file = new File(getClassesDirectory(OpenAPIScannerPluginTest.class), "example-metadata.yaml");
+        try {
+            contract = getScanner().scan(file, "example-metadata.yaml", DefaultScope.NONE);
+            assertThat(contract).isNotNull();
+        } catch (Exception e){
+            fail("Reading contract only containing container data failed", e);
         }
 
-     private TagDescriptor getTagByName(String name){
-         List<TagDescriptor> tags = contract.getTags();
-         for(TagDescriptor tag: tags)
-             if(tag.getTag().equals(name))
-                 return tag;
-         return null;
-     }
+        store.beginTransaction();
+        ExternalDocsDescriptor externalDocsWithProperties = getTagByName("issues").getExternalDocs();
+        assertThat(externalDocsWithProperties.getDescription()).isEqualTo("issues - external docs description");
+        assertThat(externalDocsWithProperties.getUrl()).isEqualTo("https://www.1.example.com");
 
+        ExternalDocsDescriptor externalDocsWithoutDescription = getTagByName("externalDocs_without_description").getExternalDocs();
+        assertThat(externalDocsWithoutDescription.getDescription()).isNull();
+        assertThat(externalDocsWithoutDescription.getUrl()).isEqualTo("https://www.2.example.com");
+
+        ExternalDocsDescriptor externalDocsWithoutUrl = getTagByName("externalDocs_without_url").getExternalDocs();
+        assertThat(externalDocsWithoutUrl.getDescription()).isEqualTo("external docs without url");
+        assertThat(externalDocsWithoutUrl.getUrl()).isNull();
+
+        ExternalDocsDescriptor externalDocsWithEmptyProps = getTagByName("externalDocs_with_empty_props").getExternalDocs();
+        assertThat(externalDocsWithEmptyProps.getDescription()).isNull();
+        assertThat(externalDocsWithEmptyProps.getUrl()).isNull();
+
+        store.commitTransaction();
+    }
+    private TagDescriptor getTagByName(String name){
+        List<TagDescriptor> tags = contract.getTags();
+        for(TagDescriptor tag: tags)
+            if(tag.getTag().equals(name))
+                return tag;
+        return null;
+    }
 }

--- a/src/test/resources/example-components.yaml
+++ b/src/test/resources/example-components.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.1.0
 info:
   title: Sample API
   description: API description in Markdown.
@@ -14,8 +14,58 @@ components:
           type: string
 
   responses:
-    Success:
+    200:
       description: "Successful operation"
+    418:
+      content:
+        multipart/form-data_example:
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+              address:
+                type: object
+              historyMetadata:
+                description: metadata in XML format
+                type: object
+              profileImage:
+                type: object
+          example: "{ id: \"idString\", address: { }, historyMetadata: { }, profileImage: { } }"
+          encoding:
+            historyMetadata:
+              contentType: application/xml; charset=utf-8
+            profileImage:
+              contentType: image/png, image/jpeg
+              headers:
+                X-Rate-Limit-Limit:
+                  description: The number of allowed requests in the current period
+                  schema:
+                    type: integer
+        multipart/form-data_examples:
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+              address:
+                type: object
+              historyMetadata:
+                description: metadata in XML format
+                type: object
+              profileImage:
+                type: object
+          examples:
+            example1:
+              value: "{ id: \"idString1\", address: { }, historyMetadata: { }, profileImage: { } }"
+            example2:
+              value: "{ id: \"idString2\", address: { }, historyMetadata: { }, profileImage: { } }"
+          encoding:
+        multipart/form-data_empty:
+          schema:
+          examples:
+          encoding:
+
 
   parameters:
     userId:

--- a/src/test/resources/example-components.yaml
+++ b/src/test/resources/example-components.yaml
@@ -87,6 +87,24 @@ components:
         application/json:
           schema:
             type: object
+          encoding:
+            property1:
+              contentType: application/xml; charset=utf-8
+              headers:
+                X-Rate-Limit-Limit:
+                  description: The number of allowed requests in the current period
+                  schema:
+                    type: integer
+              explode: true
+              allowReserved: true
+              style: spaceDelimited
+            property2:
+              contentType:
+              headers:
+              explode:
+              allowReserved:
+              style:
+
 
   headers:
     X-Request-Id:


### PR DESCRIPTION
closes #40 

[org.jqassistant.plugin.openapi.parser.OpenAPIScannerPluginTest.scanWholeContract](https://jenkins-jqa.buschmais.com/job/jqassistant-openapi-plugin-ci/161/org.jqassistant.plugin$jqassistant-openapi-plugin/testReport/org.jqassistant.plugin.openapi.parser/OpenAPIScannerPluginTest/scanWholeContract/) is currently failing due to suspected bug in schema parser (see #42)